### PR TITLE
Added lockoutTime undefined to be unlocked

### DIFF
--- a/lib/verifyUser.js
+++ b/lib/verifyUser.js
@@ -53,7 +53,7 @@ module.exports = {
                 'searchEntry', function (entry) {
                   data.raw   = entry.object;
                   data.valid = true;
-                  if (Number(entry.object.lockoutTime) == 0) {
+                  if (Number(entry.object.lockoutTime) == 0 || typeof entry.object.lockoutTime == 'undefined') {
                     if (config.debug) {
                       console.log(
                         "account not locked and valid!"

--- a/lib/verifyUser.js
+++ b/lib/verifyUser.js
@@ -53,7 +53,7 @@ module.exports = {
                 'searchEntry', function (entry) {
                   data.raw   = entry.object;
                   data.valid = true;
-                  if (Number(entry.object.lockoutTime) == 0 || typeof entry.object.lockoutTime == 'undefined') {
+                  if (Number(entry.object.lockoutTime) == 0 || typeof entry.object.lockoutTime === 'undefined') {
                     if (config.debug) {
                       console.log(
                         "account not locked and valid!"


### PR DESCRIPTION
AD may not have a lockoutTime property if the account has never been locked. When lockoutTime == null method returns account is locked. It should return unlocked. 